### PR TITLE
Refactor error messages

### DIFF
--- a/src/find-path.js
+++ b/src/find-path.js
@@ -44,7 +44,7 @@ function searchInFolders(tag, fileNameFromTag, options) {
   const componentPath = search(options.root, options.folders, fileNameFromTag, options.fileExtension);
 
   if (!componentPath) {
-    throw new Error(`[components] For the tag ${tag} was not found any template in defined root path ${options.folders.join(', ')}`);
+    throw new Error(`[components] <${tag}> could not find ${fileNameFromTag} in the defined root paths (${options.folders.join(', ')})`);
   }
 
   return componentPath;
@@ -63,7 +63,7 @@ function searchInNamespaces(tag, [namespace, fileNameFromTag], options) {
   const namespaceOption = options.namespaces.find(n => n.name === namespace.replace(options.tagPrefix, ''));
 
   if (!namespaceOption) {
-    throw new Error(`[components] Unknown component namespace ${namespace}.`);
+    throw new Error(`[components] Unknown component namespace: ${namespace}.`);
   }
 
   let componentPath;
@@ -84,7 +84,7 @@ function searchInNamespaces(tag, [namespace, fileNameFromTag], options) {
   }
 
   if (!componentPath && options.strict) {
-    throw new Error(`[components] For the tag ${tag} was not found any template in the defined namespace's base path ${namespaceOption.root}.`);
+    throw new Error(`[components] <${tag}> could not find ${fileNameFromTag} in the defined namespace base path ${namespaceOption.root}`);
   }
 
   return componentPath;

--- a/src/process-stacks.js
+++ b/src/process-stacks.js
@@ -2,7 +2,7 @@
 
 const {match} = require('posthtml/lib/api');
 const {render} = require('posthtml-render');
-const {get} = require('lodash');
+const get = require('lodash/get');
 
 /**
  * Process <push> tag

--- a/src/process-stacks.js
+++ b/src/process-stacks.js
@@ -2,6 +2,7 @@
 
 const {match} = require('posthtml/lib/api');
 const {render} = require('posthtml-render');
+const {get} = require('lodash');
 
 /**
  * Process <push> tag
@@ -13,8 +14,12 @@ const {render} = require('posthtml-render');
  */
 function processPushes(tree, content, push) {
   match.call(tree, {tag: push}, pushNode => {
+    if (get(pushNode, 'attrs.name') === '') {
+      throw new Error(`[components] <${push}> tag requires a value for the "name" attribute.`);
+    }
+
     if (!pushNode.attrs || !pushNode.attrs.name) {
-      throw new Error(`[components] Push <${push}> tag must have an attribute "name".`);
+      throw new Error(`[components] <${push}> tag requires a "name" attribute.`);
     }
 
     if (!content[pushNode.attrs.name]) {

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -59,8 +59,14 @@ test('Must fail when component is not found in defined namespace with strict mod
   await t.throwsAsync(async () => posthtml([plugin({root: './test/templates', strict: true, namespaces: [{name: 'empty-namespace', root: './test/templates/empty-namespace'}]})]).process(actual).then(result => clean(result.html)));
 });
 
-test('Must fail when push tag missing name', async t => {
+test('Must fail when push tag missing name attribute', async t => {
   const actual = `<div><push></push></div>`;
+
+  await t.throwsAsync(async () => posthtml([plugin({root: './test/templates', strict: true})]).process(actual).then(result => clean(result.html)));
+});
+
+test('Must fail when push tag missing name attribute value', async t => {
+  const actual = `<div><push name></push></div>`;
 
   await t.throwsAsync(async () => posthtml([plugin({root: './test/templates', strict: true})]).process(actual).then(result => clean(result.html)));
 });


### PR DESCRIPTION
This PR:

- refactors the `<push>` tag error so that it takes into account empty `name` attributes
- updates some path-related error messages to be more succint and give a little more context

Let me know what you think, thanks!