### PR TITLE
Add support for customizing posthtml-parser

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ You can run `npm run build` to compile them.
 |     **propsContext**     |                    `props`                    | String value used as object name inside the script to process process before passed to the component.                         |
 |    **propsAttribute**    |                    `props`                    | String value for props attribute to define props as JSON.                                                                     |
 |      **propsSlot**       |                    `props`                    | String value used to retrieve the props passed to slot via `$slots.slotName.props`.                                           |
+|     **parserOptions**    |        `{recognizeSelfClosing: true}`         | Object to configure `posthtml-parser`. By default, it enables support for self-closing component tags.                        |
 |     **expressions**      |                     `{}`                      | Object to configure `posthtml-expressions`. You can pre-set locals or customize the delimiters for example.                   |
 |       **plugins**        |                     `[]`                      | PostHTML plugins to apply for every parsed components.                                                                        |
 |       **matcher**        |         `[{tag: options.tagPrefix}]`          | Array of object used to match the tags.                                                                                       |

--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,10 @@ function processTree(options) {
 
       log(`${++processCounter}) Processing "${currentNode.tag}" from "${componentPath}"`, 'processTree');
 
-      let nextNode = parser(readFileSync(componentPath, 'utf8'), options.parserOptions);
+      let nextNode = parser(
+        readFileSync(componentPath, 'utf8'),
+        mergeWith({recognizeSelfClosing: true}, options.parserOptions)
+      );
 
       // Set filled slots
       setFilledSlots(currentNode, filledSlots, options);

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ module.exports = (options = {}) => tree => {
   options.propsContext = options.propsContext || 'props';
   options.propsAttribute = options.propsAttribute || 'props';
   options.propsSlot = options.propsSlot || 'props';
+  options.parserOptions = options.parserOptions || {recognizeSelfClosing: true};
   options.expressions = options.expressions || {};
   options.plugins = options.plugins || [];
   options.attrsParserRules = options.attrsParserRules || {};
@@ -180,7 +181,7 @@ function processTree(options) {
 
       log(`${++processCounter}) Processing "${currentNode.tag}" from "${componentPath}"`, 'processTree');
 
-      let nextNode = parser(readFileSync(componentPath, 'utf8'));
+      let nextNode = parser(readFileSync(componentPath, 'utf8'), options.parserOptions);
 
       // Set filled slots
       setFilledSlots(currentNode, filledSlots, options);


### PR DESCRIPTION
This PR adds a new `parserOptions` config option to the plugin, which allows the user to pass options to `posthtml-parser`.

By default, this option is set to `{recognizeSelfClosing: true}` so that components can also be written as self-closing - useful for those cases where you don't actually need to pass content to the component.

The user's options will be merged on top of the defaults, so that the self-closing functionality isn't accidentally disabled.

For example, right now if you have a component defined like this:

```html
<!-- divider.html -->
<div style="height: 1px; background-color: gray;"></div>
```

... and you use it like this:

```html
<h1>Title</h1>

<x-divider />

<p>Content</p>
```

... what will happen is tht everything after `<x-divider />` will be discarded, because `<x-divider />` is not recognized as a self-closing tag (this is, by default, `false` in `posthtml-parser`). So you end up with this:

```html
<h1>Title</h1>

<div style="height: 1px; background-color: gray;"></div>
```

Setting `{recognizeSelfClosing: true}` as a default resolves this issue and you're free to write components both as self-closing (`<x-divider />`) and as tag-closed (`<x-divider></x-divider>`), just like in frontend frameworks like Vue.
