### PR TITLE
build: add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "main"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This adds Dependabot so we can stay up to date with dependencies.